### PR TITLE
Remote tel prefix

### DIFF
--- a/src/Globe/Connect/Sms.php
+++ b/src/Globe/Connect/Sms.php
@@ -49,10 +49,10 @@ class Sms extends Base {
         
         // prepare request payload
         $payload = array('outboundSMSMessageRequest' => array(
-            'senderAddress' => 'tel:' . $this->params['sender'],
+            'senderAddress' => $this->params['sender'],
             'outboundSMSTextMessage'    => array(
                 'message'   => $this->params['message']),
-            'address'       => 'tel:' . $this->params['receiver_address']));
+            'address'       => $this->params['receiver_address']));
         
         // if client correlator is set
         if(isset($this->params['client_correlator'])) {


### PR DESCRIPTION
Fixes the invalid access token error.

Edit: Actually, it fixes the error when I'm trying to send an sms. I've thoroughly followed their instructions. I'm not sure if this is a proper fix. I'm guessing they've updated their API without notice.